### PR TITLE
The  method in the UserLoginResponse class had a signature

### DIFF
--- a/app/Modules/User/Http/Responses/UserLoginResponse.php
+++ b/app/Modules/User/Http/Responses/UserLoginResponse.php
@@ -21,7 +21,7 @@ class UserLoginResponse extends Response
             ->additional(['token' => $resource->token()]);
     }
 
-    protected function handleErrorResponse(Throwable $e): bool|JsonResponse
+    protected function handleErrorResponse(Throwable $e): false|JsonResponse
     {
         if ($e instanceof UnauthorizedHttpException) {
             return new ErrorResponse($e->getMessage(), status: $e->getStatusCode());


### PR DESCRIPTION
The `handleErrorResponse` method in the UserLoginResponse class had a signature
incompatibility with the parent class Dust\Base\Response. This fix ensures
that the method signature in UserLoginResponse is compatible with the
expected signature in the base class.
